### PR TITLE
Update gree_ir.h

### DIFF
--- a/gree_ir.h
+++ b/gree_ir.h
@@ -33,7 +33,7 @@ public:
     traits.set_visual_max_temperature(30);
     traits.set_visual_temperature_step(1.f);
 
-    traits.set_supports_auto_mode(true);
+    traits.set_supports_heat_cool_mode(true);
     traits.set_supports_cool_mode(true);
     traits.set_supports_heat_mode(true);
     traits.set_supports_fan_only_mode(false);


### PR DESCRIPTION
Since ESPHome version 1.19.0, set_supports_auto_mode will cause "Unavailable" state of this entity in home assistant, after changing it to set_supports_heat_cool_mode it's working again.